### PR TITLE
Add .travis.yml to have integration builds for every pull request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: java
+# Enable container-based infrastructure
+# see http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
+jdk:
+- openjdk6
+- openjdk7
+- oraclejdk8
+cache:
+  directories:
+  - $HOME/.m2/repository
+script:
+- mvn clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -231,5 +231,8 @@
   </reporting>
   <properties>
     <mavenVersion>2.0.7</mavenVersion>
+
+    <!-- Override the 1.7 set in parent -->
+    <mojo.java.target>1.6</mojo.java.target>
   </properties>
 </project>


### PR DESCRIPTION
I hope that the idea of having TravisCI builds for every PR and merge is generally acceptable.

I have seen that `org.codehaus.mojo:mojo-parent` defines the Java source and target levels at `1.4`. However, the oldest Java available in Travis is OpenJDK6, see http://docs.travis-ci.com/user/languages/java/#Testing-Against-Multiple-JDKs

So I have added OpenJDK6 plus OpenJDK7 and OracleJDK8 to the build matirix: https://github.com/mojohaus/xml-maven-plugin/commit/9fad25dec2cd3947bc3b5a2fd9fd5c26dc5594f3#diff-354f30a63fb0907d4ad57269548329e3R5

To see how and if at all the proposed `.travis.xml` file works, one of the project owners should add the TravisCI service in https://github.com/mojohaus/xml-maven-plugin/settings/hooks