### PR TITLE
Issue #1: Fix redirected homepage link

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
   <packaging>maven-plugin</packaging>
   <name>XML Maven Plugin</name>
   <version>1.0.1-SNAPSHOT</version>
+  <url>http://www.mojohaus.org/xml-maven-plugin/</url>
   <prerequisites>
     <maven>${mavenVersion}</maven>
   </prerequisites>


### PR DESCRIPTION
The problem was due to the fact that <url> tag was not specified in pom.xml and as a result homepage link in effective pom.xml was redirected.

Effective pom.xml before fix:
````xml
<groupId>org.codehaus.mojo</groupId>
<artifactId>xml-maven-plugin</artifactId>
<version>1.0.1-SNAPSHOT</version>
<packaging>maven-plugin</packaging>
<name>XML Maven Plugin</name>
<description>A plugin for various XML related tasks like validation, transformation, and the like.</description>
<url>http://www.mojohaus.org/xml-maven-plugin/xml-maven-plugin</url>
<inceptionYear>2006</inceptionYear> 
````

Effective pom.xml after fix:

````xml
<groupId>org.codehaus.mojo</groupId>
<artifactId>xml-maven-plugin</artifactId>
<version>1.0.1-SNAPSHOT</version>
<packaging>maven-plugin</packaging>
<name>XML Maven Plugin</name>
<description>A plugin for various XML related tasks like validation, transformation, and the like.</description>
<url>http://www.mojohaus.org/xml-maven-plugin/</url>
<inceptionYear>2006</inceptionYear>
````

You can check url after fix with [Wheregoes](http://www.wheregoes.com/retracer.php)

It is necessary to fix the link, because maven plugins which check links on projects web sites can have check goal and it will fail the build because of the link.