### PR TITLE
Added support for xinclude in transformation and validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,10 @@
       <email>nstolwijk@iprofs.nl</email>
     </contributor>
     <contributor>
+      <name>Georg Tsakumagos</name>
+      <email>tsakumagos@gmail.com</email>
+    </contributor>
+    <contributor>
       <name>Andrew Thornton</name>
       <email>art27@cantab.net</email>
     </contributor>

--- a/src/it/xinclude-xsd/invoker.properties
+++ b/src/it/xinclude-xsd/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean xml:validate

--- a/src/it/xinclude-xsd/pom.xml
+++ b/src/it/xinclude-xsd/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.xml</groupId>
+  <artifactId>xinclude</artifactId>
+  <version>0.1</version>
+  <name>Maven XML Plugin IT xinclude - validate</name>
+  <description>Integration Test to check xinclude awarenes for the Maven XML Plugin</description>
+  <build>
+	<plugins>
+		<plugin>
+			<groupId>org.codehaus.mojo</groupId>
+			<artifactId>xml-maven-plugin</artifactId>
+        	<version>@pom.version@</version>
+			<executions>
+				<execution>
+					<goals>
+						<goal>validate</goal>
+					</goals>
+				</execution>
+			</executions>
+			<configuration>
+				<validationSets>
+					<validationSet>
+						<xincludeAware>true</xincludeAware>
+						<dir>src/main/xml</dir>
+						<includes>
+							<include>book.xml</include>
+						</includes>
+						<systemId>src/main/xsd/schema.xsd</systemId>
+					</validationSet>
+				</validationSets>
+			</configuration>
+		</plugin>
+	</plugins>
+</build>
+<properties>
+	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+</properties>
+</project>

--- a/src/it/xinclude-xsd/src/main/xml/book.xml
+++ b/src/it/xinclude-xsd/src/main/xml/book.xml
@@ -1,0 +1,23 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<book xmlns:xi="http://www.w3.org/2001/XInclude" 
+	  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	  xsi:noNamespaceSchemaLocation="../xsd/schema.xsd" >
+	 
+	<xi:include href="chapter.xml"/>
+</book>

--- a/src/it/xinclude-xsd/src/main/xml/chapter.xml
+++ b/src/it/xinclude-xsd/src/main/xml/chapter.xml
@@ -1,0 +1,24 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<chapter xmlns:xi="http://www.w3.org/2001/XInclude" 
+	     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:noNamespaceSchemaLocation="../xsd/schema.xsd" >
+		 
+	<xi:include href="section.xml"/>
+
+</chapter>

--- a/src/it/xinclude-xsd/src/main/xml/section.xml
+++ b/src/it/xinclude-xsd/src/main/xml/section.xml
@@ -1,0 +1,22 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<section xmlns:xi="http://www.w3.org/2001/XInclude" 
+	     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	     xsi:noNamespaceSchemaLocation="../xsd/schema.xsd" >
+	Hello World
+</section>

--- a/src/it/xinclude-xsd/src/main/xsd/schema.xsd
+++ b/src/it/xinclude-xsd/src/main/xsd/schema.xsd
@@ -1,0 +1,54 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<xs:schema
+	xmlns:xi="http://www.w3.org/2001/XInclude"  
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+<xs:import namespace="http://www.w3.org/XML/1998/namespace"
+           schemaLocation="http://www.w3.org/2001/03/xml.xsd" />
+
+	<xs:element name="book" type="book"/>
+	<xs:element name="chapter" type="chapter"/>
+	<xs:element name="section" type="section"/>
+
+	<xs:complexType name="book" >
+		<xs:sequence>
+				<xs:element name="chapter" minOccurs="1" maxOccurs="unbounded"
+					type="chapter" />
+		</xs:sequence>
+		<xs:attribute ref="xml:base" use="optional"/>
+	</xs:complexType>
+
+	<xs:complexType name="chapter">
+		<xs:sequence>
+			<xs:element name="section" minOccurs="1" maxOccurs="unbounded"
+				type="section" />
+		</xs:sequence>
+		<xs:attribute ref="xml:base" use="optional"/>
+	</xs:complexType>
+
+	<xs:complexType name="section" mixed="true">
+		<xs:sequence>
+			<xs:any minOccurs="0" />
+		</xs:sequence>
+		<xs:attribute ref="xml:base" use="optional"/>
+	</xs:complexType>
+
+
+</xs:schema>

--- a/src/it/xinclude-xsl/invoker.properties
+++ b/src/it/xinclude-xsl/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean xml:transform 

--- a/src/it/xinclude-xsl/pom.xml
+++ b/src/it/xinclude-xsl/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.xml</groupId>
+  <artifactId>xinclude</artifactId>
+  <version>0.1</version>
+  <name>Maven XML Plugin IT xinclude - transform</name>
+  <description>Integration Test to check xinclude awarenes for the Maven XML Plugin</description>
+  <build>
+	<plugins>
+		<plugin>
+			<groupId>org.codehaus.mojo</groupId>
+			<artifactId>xml-maven-plugin</artifactId>
+        	<version>@pom.version@</version>
+			<configuration>
+				<transformationSets>
+					<transformationSet>
+						<xincludeAware>true</xincludeAware>
+						<dir>src/main/xml</dir>
+						<stylesheet>src/main/xsl/copy.xsl</stylesheet>
+						<includes>
+							<include>book.xml</include>
+						</includes>
+					</transformationSet>
+
+					<transformationSet>
+						<xincludeAware>false</xincludeAware>
+						<dir>src/main/xml</dir>
+						<stylesheet>src/main/xsl/copy.xsl</stylesheet>
+						<includes>
+							<include>chapter.xml</include>
+						</includes>
+					</transformationSet>
+				</transformationSets>
+				<forceCreation>true</forceCreation>
+			</configuration>
+		</plugin>
+	</plugins>
+</build>
+<properties>
+	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+</properties>
+</project>

--- a/src/it/xinclude-xsl/src/main/xml/book.xml
+++ b/src/it/xinclude-xsl/src/main/xml/book.xml
@@ -1,0 +1,20 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<book xmlns:xi="http://www.w3.org/2001/XInclude">
+ 	<xi:include href="chapter.xml" xpointer="element(/1)"/>
+</book>

--- a/src/it/xinclude-xsl/src/main/xml/chapter.xml
+++ b/src/it/xinclude-xsl/src/main/xml/chapter.xml
@@ -1,0 +1,24 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<chapter xmlns:xi="http://www.w3.org/2001/XInclude">
+ 	<xi:include href="section.xml" xpointer="element(/1)">
+ 		<xi:fallback>
+ 			<fallbackSection/>
+ 		</xi:fallback>
+ 	</xi:include>
+</chapter>

--- a/src/it/xinclude-xsl/src/main/xml/section.xml
+++ b/src/it/xinclude-xsl/src/main/xml/section.xml
@@ -1,0 +1,18 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<section xmlns:xi="http://www.w3.org/2001/XInclude">Hello World</section>

--- a/src/it/xinclude-xsl/src/main/xsl/copy.xsl
+++ b/src/it/xinclude-xsl/src/main/xsl/copy.xsl
@@ -1,0 +1,29 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	
+<xsl:template match="comment()|processing-instruction()|text()">
+    <xsl:copy/>
+  </xsl:template>
+  <xsl:template match="*">
+    <xsl:copy>
+      <xsl:copy-of select="@*"/>
+      <xsl:apply-templates select="comment()|processing-instruction()|text()|*"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/it/xinclude-xsl/verify.groovy
+++ b/src/it/xinclude-xsl/verify.groovy
@@ -1,0 +1,11 @@
+import org.codehaus.plexus.util.FileUtils
+
+File xmlFile = new File(basedir, "/target/generated-resources/xml/xslt/book.xml")
+assert xmlFile.isFile()
+
+def book = new XmlSlurper().parse(xmlFile)
+
+assert book instanceof groovy.util.slurpersupport.GPathResult
+
+assert book.chapter.section == 'Hello World'
+

--- a/src/main/java/org/codehaus/mojo/xml/TransformMojo.java
+++ b/src/main/java/org/codehaus/mojo/xml/TransformMojo.java
@@ -625,6 +625,7 @@ public class TransformMojo
             for ( int i = 0; i < transformationSets.length; i++ )
             {
                 TransformationSet transformationSet = transformationSets[i];
+                resolver.setXincludeAware( transformationSet.isXincludeAware() );
                 resolver.setValidating( transformationSet.isValidating() );
                 transform( resolver, transformationSet );
             }

--- a/src/main/java/org/codehaus/mojo/xml/ValidateMojo.java
+++ b/src/main/java/org/codehaus/mojo/xml/ValidateMojo.java
@@ -147,7 +147,23 @@ public class ValidateMojo
                 {
                     validator.setResourceResolver( pResolver );
                 }
-                validator.validate( new StreamSource( pFile ) );
+                
+                if ( pValidationSet.isXincludeAware() )
+                {
+                    SAXParserFactory spf = SAXParserFactory.newInstance();
+                    spf.setNamespaceAware( true );
+                    spf.setXIncludeAware( pValidationSet.isXincludeAware() );
+
+                    InputSource isource = new InputSource( pFile.toURI().toASCIIString() );
+                    XMLReader xmlReader = spf.newSAXParser().getXMLReader();
+                    xmlReader.setEntityResolver( pResolver );
+
+                    validator.validate( new SAXSource( xmlReader, isource ) );
+                }
+                else
+                {
+                    validator.validate( new StreamSource( pFile ) );
+                }
             }
         }
         catch ( SAXParseException e )
@@ -342,6 +358,7 @@ public class ValidateMojo
             for ( int i = 0; i < validationSets.length; i++ )
             {
                 ValidationSet validationSet = validationSets[i];
+                resolver.setXincludeAware(validationSet.isValidating() );
                 resolver.setValidating( validationSet.isValidating() );
                 validate( resolver, validationSet );
             }

--- a/src/main/java/org/codehaus/mojo/xml/transformer/TransformationSet.java
+++ b/src/main/java/org/codehaus/mojo/xml/transformer/TransformationSet.java
@@ -56,6 +56,8 @@ public class TransformationSet
 
     private boolean validating;
 
+    private boolean xincludeAware;
+
     /**
      * Sets patterns of files, which are being excluded from the transformation set.
      */
@@ -286,5 +288,23 @@ public class TransformationSet
     public void setAttributes( NameValuePair[] pAttributes )
     {
         attributes = pAttributes;
+    }
+    
+    /**
+     * Returns, whether the transformer should create xinclude aware XML parsers for reading XML documents. The default
+     * value is false.
+     */    
+    public boolean isXincludeAware()
+    {
+        return xincludeAware;
+    }
+    
+    /**
+     * Sets, whether the transformer should create xinclude aware XML parsers for reading XML documents. The default value
+     * is false.
+     */
+    public void setXincludeAware(boolean pXIncludeAware)
+    {
+        xincludeAware = pXIncludeAware;
     }
 }

--- a/src/main/java/org/codehaus/mojo/xml/validation/ValidationSet.java
+++ b/src/main/java/org/codehaus/mojo/xml/validation/ValidationSet.java
@@ -41,6 +41,8 @@ public class ValidationSet
     private String[] excludes;
 
     private boolean skipDefaultExcludes;
+    
+    private boolean xincludeAware;
 
     /**
      * Returns a directory, which is scanned for files to validate.
@@ -180,5 +182,23 @@ public class ValidationSet
     public void setValidating( boolean pValidating )
     {
         validating = pValidating;
+    }
+    
+    /**
+     * Returns, whether the validator should create xinclude aware XML parsers for reading XML documents. The default
+     * value is false.
+     */    
+    public boolean isXincludeAware()
+    {
+        return xincludeAware;
+    }
+    
+    /**
+     * Sets, whether the validator should create xinclude aware XML parsers for reading XML documents. The default value
+     * is false.
+     */
+    public void setXincludeAware(boolean pXIncludeAware)
+    {
+        xincludeAware = pXIncludeAware;
     }
 }

--- a/src/site/apt/transformation.apt
+++ b/src/site/apt/transformation.apt
@@ -151,3 +151,5 @@ Transformation Set Configuration
 |                     | the fileset. A stylesheet must be specified, there is no        |
 |                     | default.                                                        |
 *---------------------+-----------------------------------------------------------------+
+| xincludeAware       | If 'true' enables XInclude support. Disabled by default.        |
+*---------------------+-----------------------------------------------------------------+

--- a/src/site/apt/validation.apt
+++ b/src/site/apt/validation.apt
@@ -135,3 +135,5 @@ Validation Set Configuration
 | skipDefaultExcludes | Specifies whether the maven's default exludes should NOT        |
 |                     | be added to the excludes list.                                  |
 *---------------------+-----------------------------------------------------------------+
+| xincludeAware       | If 'true' enables XInclude support. Disabled by default.        |
+*---------------------+-----------------------------------------------------------------+

--- a/src/test/java/org/codehaus/mojo/xml/test/ValidateMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/xml/test/ValidateMojoTest.java
@@ -86,4 +86,13 @@ public class ValidateMojoTest
     {
         runTest( "src/test/it12" );
     }
+
+    /**
+     * Builds and runs the xinclude test project
+     */
+    public void testXIncludeEnabled()
+        throws Exception
+    {
+        runTest( "src/test/xinclude-xsd" );
+    }
 }

--- a/src/test/xinclude-xsd/pom.xml
+++ b/src/test/xinclude-xsd/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.xml</groupId>
+  <artifactId>xinclude</artifactId>
+  <version>0.1</version>
+  <name>Maven XML Plugin IT xinclude</name>
+  <description>Integration Test to check xinclude awarenes for the Maven XML Plugin</description>
+  <build>
+	<plugins>
+		<plugin>
+			<groupId>org.codehaus.mojo</groupId>
+			<artifactId>xml-maven-plugin</artifactId>
+			<version>1.0.2-SNAPSHOT</version>
+			<executions>
+				<execution>
+					<goals>
+						<goal>validate</goal>
+					</goals>
+				</execution>
+			</executions>
+			<configuration>
+				<validationSets>
+					<validationSet>
+						<xincludeAware>true</xincludeAware>
+						<dir>xml</dir>
+						<includes>
+							<include>book.xml</include>
+						</includes>
+						<systemId>xsd/schema.xsd</systemId>
+					</validationSet>
+				</validationSets>
+			</configuration>
+		</plugin>
+	</plugins>
+</build>
+<properties>
+	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+</properties>
+</project>

--- a/src/test/xinclude-xsd/xml/book.xml
+++ b/src/test/xinclude-xsd/xml/book.xml
@@ -1,0 +1,23 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<book xmlns:xi="http://www.w3.org/2001/XInclude" 
+	  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	  xsi:noNamespaceSchemaLocation="../xsd/schema.xsd" >
+	  
+	<xi:include href="chapter.xml"/>
+</book>

--- a/src/test/xinclude-xsd/xml/chapter.xml
+++ b/src/test/xinclude-xsd/xml/chapter.xml
@@ -1,0 +1,24 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<chapter xmlns:xi="http://www.w3.org/2001/XInclude" 
+	     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:noNamespaceSchemaLocation="../xsd/schema.xsd" >
+		 
+	<xi:include href="section.xml"/>
+
+</chapter>

--- a/src/test/xinclude-xsd/xml/section.xml
+++ b/src/test/xinclude-xsd/xml/section.xml
@@ -1,0 +1,22 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<section xmlns:xi="http://www.w3.org/2001/XInclude" 
+	     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	     xsi:noNamespaceSchemaLocation="../xsd/schema.xsd" >
+	Hello World
+</section>

--- a/src/test/xinclude-xsd/xsd/schema.xsd
+++ b/src/test/xinclude-xsd/xsd/schema.xsd
@@ -1,0 +1,54 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<xs:schema
+	xmlns:xi="http://www.w3.org/2001/XInclude"  
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+<xs:import namespace="http://www.w3.org/XML/1998/namespace"
+           schemaLocation="http://www.w3.org/2001/03/xml.xsd" />
+
+	<xs:element name="book" type="book"/>
+	<xs:element name="chapter" type="chapter"/>
+	<xs:element name="section" type="section"/>
+
+	<xs:complexType name="book" >
+		<xs:sequence>
+				<xs:element name="chapter" minOccurs="0" maxOccurs="unbounded"
+					type="chapter" />
+		</xs:sequence>
+		<xs:attribute ref="xml:base" use="optional"/>
+	</xs:complexType>
+
+	<xs:complexType name="chapter">
+		<xs:sequence>
+			<xs:element name="section" minOccurs="0" maxOccurs="unbounded"
+				type="section" />
+		</xs:sequence>
+		<xs:attribute ref="xml:base" use="optional"/>
+	</xs:complexType>
+
+	<xs:complexType name="section" mixed="true">
+		<xs:sequence>
+			<xs:any minOccurs="0" />
+		</xs:sequence>
+		<xs:attribute ref="xml:base" use="optional"/>
+	</xs:complexType>
+
+
+</xs:schema>

--- a/src/test/xinclude-xsl/pom.xml
+++ b/src/test/xinclude-xsl/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.xml</groupId>
+  <artifactId>xinclude</artifactId>
+  <version>0.1</version>
+  <name>Maven XML Plugin IT xinclude</name>
+  <description>Integration Test to check xinclude awarenes for the Maven XML Plugin</description>
+  <build>
+	<plugins>
+		<plugin>
+			<groupId>org.codehaus.mojo</groupId>
+			<artifactId>xml-maven-plugin</artifactId>
+			<version>1.0.2-SNAPSHOT</version>
+			<configuration>
+				<transformationSets>
+					<transformationSet>
+						<xincludeAware>true</xincludeAware>
+						<dir>xml</dir>
+						<stylesheet>xsl/copy.xsl</stylesheet>
+						<includes>
+							<include>book.xml</include>
+						</includes>
+					</transformationSet>
+
+					<transformationSet>
+						<xincludeAware>false</xincludeAware>
+						<dir>xml</dir>
+						<stylesheet>xsl/copy.xsl</stylesheet>
+						<includes>
+							<include>chapter.xml</include>
+						</includes>
+					</transformationSet>
+				</transformationSets>
+				<forceCreation>true</forceCreation>
+			</configuration>
+		</plugin>
+	</plugins>
+</build>
+<properties>
+	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+</properties>
+</project>

--- a/src/test/xinclude-xsl/xml/book.xml
+++ b/src/test/xinclude-xsl/xml/book.xml
@@ -1,0 +1,20 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<book xmlns:xi="http://www.w3.org/2001/XInclude">
+ 	<xi:include href="chapter.xml" xpointer="element(/1)"/>
+</book>

--- a/src/test/xinclude-xsl/xml/chapter.xml
+++ b/src/test/xinclude-xsl/xml/chapter.xml
@@ -1,0 +1,24 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<chapter xmlns:xi="http://www.w3.org/2001/XInclude">
+ 	<xi:include href="section.xml" xpointer="element(/1)">
+ 		<xi:fallback>
+ 			<fallbackSection/>
+ 		</xi:fallback>
+ 	</xi:include>
+</chapter>

--- a/src/test/xinclude-xsl/xml/section.xml
+++ b/src/test/xinclude-xsl/xml/section.xml
@@ -1,0 +1,20 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<section xmlns:xi="http://www.w3.org/2001/XInclude">
+	Hello World
+</section>

--- a/src/test/xinclude-xsl/xsl/copy.xsl
+++ b/src/test/xinclude-xsl/xsl/copy.xsl
@@ -1,0 +1,29 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	
+<xsl:template match="comment()|processing-instruction()|text()">
+    <xsl:copy/>
+  </xsl:template>
+  <xsl:template match="*">
+    <xsl:copy>
+      <xsl:copy-of select="@*"/>
+      <xsl:apply-templates select="comment()|processing-instruction()|text()|*"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Added integration- and unit tests to prove functionality. Extend site to document new attributes in plug-in configuration. I'm using this plug in to generate documentation via docBook xslt. I really need this feature to split the manual in handy pieces.

