### PR TITLE
Issue #16 (mojo parameter sanity checks) - test cases and fixes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,10 @@
       <name>Aleksei Valikov</name>
       <email>valikov@gmx.net</email>
     </contributor>
+    <contributor>
+      <name>Ross Lamont</name>
+      <email>rlamont@componentcorp.com</email>
+    </contributor>
   </contributors>
   <licenses>
     <license>

--- a/src/main/java/org/codehaus/mojo/xml/AbstractXmlMojo.java
+++ b/src/main/java/org/codehaus/mojo/xml/AbstractXmlMojo.java
@@ -116,7 +116,7 @@ public abstract class AbstractXmlMojo
     /**
      * Returns the plugins catalog files.
      */
-    protected void setCatalogs( List pCatalogFiles, List pCatalogUrls )
+    protected void setCatalogs( List pCatalogFiles, List pCatalogUrls ) throws MojoExecutionException
     {
         if ( catalogs == null || catalogs.length == 0 )
         {
@@ -132,7 +132,11 @@ public abstract class AbstractXmlMojo
             }
             catch ( MalformedURLException e )
             {
-                pCatalogFiles.add( asAbsoluteFile( new File( catalogs[i] ) ) );
+                File absoluteCatalog = asAbsoluteFile( new File( catalogs[i] ) );
+                if (!absoluteCatalog.exists() || !absoluteCatalog.isFile()){
+                    throw new MojoExecutionException("That catalog does not exist:"+absoluteCatalog.getPath(), e);
+                }
+                pCatalogFiles.add(absoluteCatalog  );
             }
         }
     }
@@ -154,7 +158,7 @@ public abstract class AbstractXmlMojo
      * Scans a directory for files and returns a set of path names.
      */
     protected String[] getFileNames( File pDir, String[] pIncludes, String[] pExcludes )
-        throws MojoFailureException
+        throws MojoFailureException, MojoExecutionException
     {
         if ( pDir == null )
         {
@@ -164,9 +168,8 @@ public abstract class AbstractXmlMojo
         final File dir = asAbsoluteFile( pDir );
         if ( !dir.isDirectory() )
         {
-            getLog().warn( "The directory " + dir.getPath()
-                + ", which is a base directory of a ValidationSet or TransformationSet, does not exist." );
-            return new String[0];
+            throw new MojoExecutionException("The directory " + dir.getPath()
+                + ", which is a base directory of a ValidationSet or TransformationSet, does not exist.");
         }
         final DirectoryScanner ds = new DirectoryScanner();
         ds.setBasedir( dir );
@@ -206,7 +209,7 @@ public abstract class AbstractXmlMojo
      * Scans a directory for files and returns a set of {@link File} instances.
      */
     protected File[] getFiles( File pDir, String[] pIncludes, String[] pExcludes )
-        throws MojoFailureException
+        throws MojoFailureException, MojoExecutionException
     {
         return asFiles( pDir, getFileNames( pDir, pIncludes, pExcludes ) );
     }

--- a/src/test/it13/catalog.xml
+++ b/src/test/it13/catalog.xml
@@ -1,0 +1,21 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <public publicId="--COUNTER--"
+          uri="schema.xsd"/>
+</catalog>

--- a/src/test/it13/pom.xml
+++ b/src/test/it13/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.xml</groupId>
+  <artifactId>it3</artifactId>
+  <version>0.1</version>
+  <name>Maven XML Plugin IT 3</name>
+  <description>Integration Test 3 for the Maven XML Plugin</description>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>xml-maven-plugin</artifactId>
+        <version>0.2</version>
+        <configuration>
+          <validationSets>
+            <validationSet>
+              <dir>xml</dir>
+              <publicId>--COUNTER--</publicId>
+            </validationSet>
+          </validationSets>
+          <catalogs>
+            <catalog>catalog-not-here.xml</catalog>
+          </catalogs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/it13/schema.xsd
+++ b/src/test/it13/schema.xsd
@@ -1,0 +1,30 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified" attributeFormDefault="unqualified"
+    targetNamespace="xyz0">
+  <xs:element name="counter">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" minOccurs="0" maxOccurs="unbounded">
+          <xs:complexType/>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/test/it13/xml/doc1.xml
+++ b/src/test/it13/xml/doc1.xml
@@ -1,0 +1,19 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<counter xmlns="xyz0"><item/><item/><item/></counter>
+

--- a/src/test/it14/pom.xml
+++ b/src/test/it14/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.xml</groupId>
+  <artifactId>it14</artifactId>
+  <version>0.1</version>
+  <name>Maven XML Plugin IT 14</name>
+  <description>Integration Test 14 for the Maven XML Plugin</description>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>xml-maven-plugin</artifactId>
+        <version>1.0.2-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <validationSets>
+            <validationSet>
+              <dir>xml-not-here</dir>
+            </validationSet>
+          </validationSets>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/it14/xml/doc1.xml
+++ b/src/test/it14/xml/doc1.xml
@@ -1,0 +1,18 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<doc1>A sample document, which should be validatable without any problems.</doc1>

--- a/src/test/java/org/codehaus/mojo/xml/test/ValidateMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/xml/test/ValidateMojoTest.java
@@ -88,6 +88,36 @@ public class ValidateMojoTest
     }
 
     /**
+     * Builds and runs the it13 test project (Issue #16)
+     */
+    public void testIt13()
+        throws Exception
+    {
+        try{
+            runTest( "src/test/it13" );
+            fail("Catalog file does not exist - an exception should have been thrown");
+        }
+        catch(MojoExecutionException e){
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Builds and runs the it13 test project (Issue #16)
+     */
+    public void testIt14()
+        throws Exception
+    {
+        try{
+            runTest( "src/test/it14" );
+            fail("Errorneous Directory name in config should have thrown an exception");
+        }
+        catch(MojoExecutionException e){
+            e.printStackTrace();
+        }
+    }
+
+    /**
      * Builds and runs the xinclude test project
      */
     public void testXIncludeEnabled()


### PR DESCRIPTION
Specifically:
 - ensure that the "dir" parameter points to an existent directory.  Current
behaviour is to ignore the directory and to report success.
 - ensure that any "catalog" parameter points to an existent file.  Current behaviour
is to ignore the catalog silently.