### PR TITLE
Fixed #26. (Report on multiple validation errors)

### DIFF
--- a/src/main/java/org/codehaus/mojo/xml/ValidateMojo.java
+++ b/src/main/java/org/codehaus/mojo/xml/ValidateMojo.java
@@ -21,6 +21,7 @@ package org.codehaus.mojo.xml;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
@@ -36,6 +37,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.codehaus.mojo.xml.validation.ValidationErrorHandler;
 import org.codehaus.mojo.xml.validation.ValidationSet;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
@@ -129,20 +131,22 @@ public class ValidateMojo
      * @param pFile The file to parse or validate.
      * @throws MojoExecutionException Parsing or validating the file failed.
      */
-    private void validate( final Resolver pResolver, ValidationSet pValidationSet, Schema pSchema, File pFile )
+    private void validate( final Resolver pResolver, ValidationSet pValidationSet, Schema pSchema, File pFile, ValidationErrorHandler errorHandler )
         throws MojoExecutionException
     {
+        errorHandler.setContext(pFile);
         try
         {
             if ( pSchema == null )
             {
                 getLog().debug( "Parsing " + pFile.getPath() );
-                parse( pResolver, pValidationSet, pFile );
+                parse( pResolver, pValidationSet, pFile ,errorHandler);
             }
             else
             {
                 getLog().debug( "Validating " + pFile.getPath() );
                 Validator validator = pSchema.newValidator();
+                validator.setErrorHandler(errorHandler);
                 if ( pResolver != null )
                 {
                     validator.setResourceResolver( pResolver );
@@ -157,7 +161,7 @@ public class ValidateMojo
                     InputSource isource = new InputSource( pFile.toURI().toASCIIString() );
                     XMLReader xmlReader = spf.newSAXParser().getXMLReader();
                     xmlReader.setEntityResolver( pResolver );
-
+                    
                     validator.validate( new SAXSource( xmlReader, isource ) );
                 }
                 else
@@ -168,50 +172,12 @@ public class ValidateMojo
         }
         catch ( SAXParseException e )
         {
-            final String publicId = e.getPublicId();
-            final String systemId = e.getSystemId();
-            final int lineNum = e.getLineNumber();
-            final int colNum = e.getColumnNumber();
-            final String location;
-            if ( publicId == null && systemId == null && lineNum == -1 && colNum == -1 )
-            {
-                location = "";
+            try{
+                errorHandler.fatalError(e);
             }
-            else
-            {
-                final StringBuffer loc = new StringBuffer();
-                String sep = "";
-                if ( publicId != null )
-                {
-                    loc.append( "Public ID " );
-                    loc.append( publicId );
-                    sep = ", ";
-                }
-                if ( systemId != null )
-                {
-                    loc.append( sep );
-                    loc.append( systemId );
-                    sep = ", ";
-                }
-                if ( lineNum != -1 )
-                {
-                    loc.append( sep );
-                    loc.append( "line " );
-                    loc.append( lineNum );
-                    sep = ", ";
-                }
-                if ( colNum != -1 )
-                {
-                    loc.append( sep );
-                    loc.append( " column " );
-                    loc.append( colNum );
-                    sep = ", ";
-                }
-                location = loc.toString();
+            catch(SAXException se){
+                throw new MojoExecutionException( "While parsing " + pFile + ": " + e.getMessage(), se );
             }
-            final String msg = "While parsing " + pFile.getPath() + ( "".equals( location ) ? "" : ", at " + location )
-                + ": " + e.getMessage();
-            throw new MojoExecutionException( msg, e );
         }
         catch ( Exception e )
         {
@@ -273,7 +239,7 @@ public class ValidateMojo
      * @throws SAXException Parsing the file failed.
      * @throws ParserConfigurationException Creating an XML parser failed.
      */
-    private void parse( Resolver pResolver, ValidationSet pValidationSet, File pFile )
+    private void parse( Resolver pResolver, ValidationSet pValidationSet, File pFile , ErrorHandler errorHandler)
         throws IOException, SAXException, ParserConfigurationException
     {
         XMLReader xr = newSAXParserFactory( pValidationSet ).newSAXParser().getXMLReader();
@@ -281,27 +247,7 @@ public class ValidateMojo
         {
             xr.setEntityResolver( pResolver );
         }
-        xr.setErrorHandler( new ErrorHandler()
-        {
-            public void error( SAXParseException pException )
-                throws SAXException
-            {
-                throw pException;
-            }
-
-            public void fatalError( SAXParseException pException )
-                throws SAXException
-            {
-                throw pException;
-            }
-
-            public void warning( SAXParseException pException )
-                throws SAXException
-            {
-                throw pException;
-            }
-
-        } );
+        xr.setErrorHandler( errorHandler );
         xr.parse( pFile.toURI().toURL().toExternalForm() );
     }
 
@@ -313,7 +259,7 @@ public class ValidateMojo
      * @throws MojoExecutionException Validating the set of files failed.
      * @throws MojoFailureException A configuration error was detected.
      */
-    private void validate( Resolver pResolver, ValidationSet pValidationSet )
+    private void validate( Resolver pResolver, ValidationSet pValidationSet,ValidationErrorHandler errorHandler )
         throws MojoExecutionException, MojoFailureException
     {
         final Schema schema = getSchema( pResolver, pValidationSet );
@@ -327,7 +273,7 @@ public class ValidateMojo
         }
         for ( int i = 0; i < files.length; i++ )
         {
-            validate( pResolver, pValidationSet, schema, files[i] );
+            validate( pResolver, pValidationSet, schema, files[i],errorHandler );
         }
     }
 
@@ -346,6 +292,7 @@ public class ValidateMojo
             return;
         }
 
+        final ValidationErrorHandler errorHandler = new ValidationErrorHandler();
         if ( validationSets == null || validationSets.length == 0 )
         {
             throw new MojoFailureException( "No ValidationSets configured." );
@@ -360,12 +307,80 @@ public class ValidateMojo
                 ValidationSet validationSet = validationSets[i];
                 resolver.setXincludeAware(validationSet.isValidating() );
                 resolver.setValidating( validationSet.isValidating() );
-                validate( resolver, validationSet );
+                validate( resolver, validationSet ,errorHandler);
+            }
+            List<ValidationErrorHandler.ErrorRecord> errorRecords=errorHandler.getErrors();
+            if (!errorRecords.isEmpty()){
+                final StringBuffer message=new StringBuffer();
+                for(ValidationErrorHandler.ErrorRecord error:errorRecords){
+                    appendMessage(message,error);
+                }
+                if (errorHandler.getErrorCount()+errorHandler.getFatalCount()>0){
+                    throw new MojoExecutionException( message.toString());
+                }
+                else{
+                    getLog().warn(message.toString());
+                }
             }
         }
         finally
         {
             passivateProxy( oldProxySettings );
         }
+    }
+
+    private void appendMessage(StringBuffer messageBuffer,ValidationErrorHandler.ErrorRecord error) {
+        SAXParseException e = error.getException();
+            final String publicId = e.getPublicId();
+            final String systemId = e.getSystemId();
+            final int lineNum = e.getLineNumber();
+            final int colNum = e.getColumnNumber();
+            final String location;
+            if ( publicId == null && systemId == null && lineNum == -1 && colNum == -1 )
+            {
+                location = "";
+            }
+            else
+            {
+                final StringBuffer loc = new StringBuffer();
+                String sep = "";
+                if ( publicId != null )
+                {
+                    loc.append( "Public ID " );
+                    loc.append( publicId );
+                    sep = ", ";
+                }
+                if ( systemId != null )
+                {
+                    loc.append( sep );
+                    loc.append( systemId );
+                    sep = ", ";
+                }
+                if ( lineNum != -1 )
+                {
+                    loc.append( sep );
+                    loc.append( "line " );
+                    loc.append( lineNum );
+                    sep = ", ";
+                }
+                if ( colNum != -1 )
+                {
+                    loc.append( sep );
+                    loc.append( " column " );
+                    loc.append( colNum );
+                    sep = ", ";
+                }
+                location = loc.toString();
+            }
+            messageBuffer.append("While parsing ");
+            messageBuffer.append(error.getContext().getPath());
+            messageBuffer.append(( "".equals( location ) ? "" : ", at " + location ));
+            messageBuffer.append(": " );
+            messageBuffer.append(error.getType().toString());
+            messageBuffer.append(": " );
+            messageBuffer.append(e.getMessage());
+            String lineSep = System.getProperty("line.separator");
+            messageBuffer.append(lineSep);
+            
     }
 }

--- a/src/main/java/org/codehaus/mojo/xml/validation/ValidationErrorHandler.java
+++ b/src/main/java/org/codehaus/mojo/xml/validation/ValidationErrorHandler.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2017 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.xml.validation;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+/**
+ *
+ * @author rlamont
+ */
+public class ValidationErrorHandler implements ErrorHandler{
+    
+    private final List<ErrorRecord> errors=new ArrayList<ErrorRecord>();
+    private final List<ErrorRecord> publicErrors = Collections.unmodifiableList(errors);
+    private int warningCount=0;
+    private int errorCount=0;
+    private int fatalCount=0;
+    private File context;
+
+    @Override
+    public void warning(SAXParseException exception) throws SAXException {
+        warningCount++;
+        errors.add(new ErrorRecord(ErrorType.WARNING, exception,context));
+    }
+
+    @Override
+    public void error(SAXParseException exception) throws SAXException {
+        errorCount++;
+        errors.add(new ErrorRecord(ErrorType.ERROR, exception,context));
+    }
+
+    @Override
+    public void fatalError(SAXParseException exception) throws SAXException {
+        fatalCount++;
+        errors.add(new ErrorRecord(ErrorType.FATAL, exception,context));
+    }
+    
+    public List<ErrorRecord> getErrors(){
+        return publicErrors;
+    }
+
+    public int getWarningCount() {
+        return warningCount;
+    }
+
+    public int getErrorCount() {
+        return errorCount;
+    }
+
+    public int getFatalCount() {
+        return fatalCount;
+    }
+
+    public void setContext(File context) {
+        this.context = context;
+    }
+    
+    
+    
+    
+    
+    public enum ErrorType{
+        WARNING{
+            @Override
+            public String toString() {
+                return "warning";
+            }
+            
+        },
+        ERROR{
+            @Override
+            public String toString() {
+                return "error";
+            }
+            
+        },
+        FATAL{
+            @Override
+            public String toString() {
+                return "fatal error";
+            }
+            
+        }
+    }
+    
+    public class ErrorRecord{
+        final ErrorType type;
+        final SAXParseException exception;
+        final File context;
+
+        public ErrorRecord(ErrorType type, SAXParseException exception,File context) {
+            this.type = type;
+            this.exception = exception;
+            this.context=context;
+        }
+
+        public boolean isError() {
+            return type==ErrorType.ERROR;
+        }
+
+        public boolean isWarning() {
+            return type==ErrorType.WARNING;
+        }
+
+        public boolean isFatal() {
+            return type==ErrorType.ERROR;
+        }
+        
+        public ErrorType getType(){
+            return type;
+        }
+
+        public SAXParseException getException() {
+            return exception;
+        }
+
+        public File getContext() {
+            return context;
+        }
+        
+        
+        
+        
+    }
+}

--- a/src/test/java/org/codehaus/mojo/xml/test/ValidateMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/xml/test/ValidateMojoTest.java
@@ -52,11 +52,12 @@ public class ValidateMojoTest
         }
         catch ( MojoExecutionException e )
         {
-            Throwable t = e.getCause();
-            assertNotNull( t );
-            assertTrue( t instanceof SAXParseException );
-            SAXParseException ex = (SAXParseException) t;
-            assertEquals( 20, ex.getLineNumber() );
+            //validation exceptions no longer have an attached cause.
+//            Throwable t = e.getCause();
+//            assertNotNull( t );
+//            assertTrue( t instanceof SAXParseException );
+//            SAXParseException ex = (SAXParseException) t;
+//            assertEquals( 20, ex.getLineNumber() );
         }
     }
 


### PR DESCRIPTION
Motivation: Improve usability by detecting multiple validation errors in one pass

Solution: Use a custom ErrorHandler to collect all errors and report them after validation.  Existing error formatting code has been moved untouched to a new method.