### PR TITLE
Fixed #21 (support for  ISO/IEC 19757-11:2011  xml-model processing instruction)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.componentcorp.xml.validation</groupId>
+      <artifactId>jxvc</artifactId>
+      <version>0.9.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.componentcorp.xml.validation</groupId>
+      <artifactId>relaxng-compact</artifactId>
+      <version>0.9.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
       <scope>provided</scope>

--- a/src/test/it15/catalog.xml
+++ b/src/test/it15/catalog.xml
@@ -1,0 +1,21 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <system systemId="http://mojohaus.org/schema/maven-xml/schema.rnc"
+          uri="schema.rnc"/>
+</catalog>

--- a/src/test/it15/pom.xml
+++ b/src/test/it15/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.xml</groupId>
+  <artifactId>it15</artifactId>
+  <version>0.1</version>
+  <name>Maven XML Plugin IT 15</name>
+  <description>Integration Test 15 for the Maven XML Plugin</description>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>xml-maven-plugin</artifactId>
+        <version>0.2</version>
+        <configuration>
+          <validationSets>
+            <validationSet>
+              <dir>xml</dir>
+              <schemaLanguage>http://componentcorp.com/xml/ns/xml-model/1.0</schemaLanguage>
+            </validationSet>
+          </validationSets>
+          <catalogs>
+            <catalog>catalog.xml</catalog>
+          </catalogs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/it15/schema.rnc
+++ b/src/test/it15/schema.rnc
@@ -1,0 +1,5 @@
+
+element counter { 
+    
+    element item { empty }*
+}

--- a/src/test/it15/xml/doc1.xml
+++ b/src/test/it15/xml/doc1.xml
@@ -1,0 +1,21 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+
+<?xml-model href="http://mojohaus.org/schema/maven-xml/schema.rnc" schematypens="http://www.iana.org/assignments/media-types/application/relax-ng-compact-syntax" ?>
+<counter ><item/><item/><item/></counter>
+

--- a/src/test/java/org/codehaus/mojo/xml/test/ValidateMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/xml/test/ValidateMojoTest.java
@@ -117,6 +117,19 @@ public class ValidateMojoTest
         }
     }
 
+    public void testIt15()
+        throws Exception
+    {
+        try{
+            runTest( "src/test/it15" );
+        }
+        catch(Exception e){
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    
     /**
      * Builds and runs the xinclude test project
      */


### PR DESCRIPTION
Motivation: support the validation approaches specified in ISO/IEC 19757-11:2011 - which in turn provides immediate standardised support for RelaxNG (XML and compact) and in theory support for Schematron and NVDL

Solution: the [jxvc](https://github.com/rosslamont/jxvc) project provides an implementation of ISO/IEC 19757-11:2011 as well as wrappers for RelaxNG validators.  This solution implements the special zero argument Validator constructor (via Schema.newValidator()) which xml-maven-plugin does not currently support.  The fix has been to special case the schemaLanguage used by jxvc so that the zero arg constructor (factory method) can be invoked.