### PR TITLE
Fixed #28 (support jdk6 on travis trusty builds)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,36 @@ language: java
 # Enable container-based infrastructure
 # see http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
-jdk:
-- openjdk6
-- openjdk7
-- oraclejdk8
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk
+
 cache:
   directories:
   - $HOME/.m2/repository
 script:
 - mvn clean verify
+
+matrix:
+  include:
+  - jdk: openjdk6
+    env: CUSTOM_MVN_VERION="3.2.5"
+  - jdk: openjdk7
+    env: CUSTOM_MVN_VERION="3.3.9"
+  - jdk: oraclejdk8
+    env: CUSTOM_MVN_VERION="3.5.0"
+
+install:
+  - if [[ -n "${CUSTOM_MVN_VERION}" ]]; then
+      echo "Download Maven ${CUSTOM_MVN_VERION}....";
+      if [[ "${CUSTOM_MVN_VERION}" == "3.0" ]]; then
+        wget https://archive.apache.org/dist/maven/binaries/apache-maven-3.0-bin.zip || travis_terminate 1;
+      else
+        wget https://archive.apache.org/dist/maven/maven-3/${CUSTOM_MVN_VERION}/binaries/apache-maven-${CUSTOM_MVN_VERION}-bin.zip || travis_terminate 1;
+      fi;
+      unzip -qq apache-maven-${CUSTOM_MVN_VERION}-bin.zip || travis_terminate 1;
+      export M2_HOME=$PWD/apache-maven-${CUSTOM_MVN_VERION};
+      export PATH=$M2_HOME/bin:$PATH;
+      mvn -version;
+    fi


### PR DESCRIPTION
Motivation: openjdk6 builds no longer work because openjdk6 is not available on travis trusty environments and maven version seems to have been upgraded past 3.3.0 (which was built on jdk7)

Fix: 
 - use apt to fetch openjdk 6
 - use script to fetch specific versions of maven for different idk environments 