### PR TITLE
Fixed #19 (New 'catalogHandling' setting)

### DIFF
--- a/src/main/java/org/codehaus/mojo/xml/AbstractXmlMojo.java
+++ b/src/main/java/org/codehaus/mojo/xml/AbstractXmlMojo.java
@@ -76,6 +76,29 @@ public abstract class AbstractXmlMojo
      */
     @Parameter
     private String[] catalogs;
+    
+    public enum CatalogHandling{
+        /**
+         * Unmatched entities are resolved through URI resolution
+         */
+        passThrough,
+        /**
+         * Unmatched entities are resolved through file only URI resolution
+         */
+        local,
+        /**
+         * Unmatched entities generate an error
+         */
+        strict
+        
+        
+    }
+    
+    /**
+     * How to handle entities which cannot be found in any catalog.
+     */
+    @Parameter ( defaultValue="passThrough")
+    private CatalogHandling catalogHandling;
 
     /**
      * Plexus resource manager used to obtain XSL.
@@ -85,6 +108,11 @@ public abstract class AbstractXmlMojo
 
     private boolean locatorInitialized;
 
+    public AbstractXmlMojo() {
+    }
+
+    
+    
     /**
      * Returns the maven project.
      */
@@ -151,7 +179,7 @@ public abstract class AbstractXmlMojo
         List catalogUrls = new ArrayList();
         setCatalogs( catalogFiles, catalogUrls );
 
-        return new Resolver( getBasedir(), catalogFiles, catalogUrls, getLocator(), getLog().isDebugEnabled() );
+        return new Resolver( getBasedir(), catalogFiles, catalogUrls, getLocator(), catalogHandling,getLog().isDebugEnabled() );
     }
 
     /**
@@ -352,4 +380,17 @@ public abstract class AbstractXmlMojo
     {
         return skip;
     }
+    
+    void checkCatalogHandling() throws MojoFailureException{
+        if (getCatalogHandling()==null){
+            throw new MojoFailureException("Illegal value for catalogHandling parameter");
+        }
+
+    }
+
+    protected CatalogHandling getCatalogHandling() {
+        return catalogHandling;
+    }
+    
+    
 }

--- a/src/main/java/org/codehaus/mojo/xml/TransformMojo.java
+++ b/src/main/java/org/codehaus/mojo/xml/TransformMojo.java
@@ -617,6 +617,7 @@ public class TransformMojo
         {
             throw new MojoFailureException( "No TransformationSets configured." );
         }
+        checkCatalogHandling();
 
         Object oldProxySettings = activateProxy();
         try

--- a/src/main/java/org/codehaus/mojo/xml/ValidateMojo.java
+++ b/src/main/java/org/codehaus/mojo/xml/ValidateMojo.java
@@ -108,8 +108,8 @@ public class ValidateMojo
             if ( inputSource == null )
             {
                 inputSource = new InputSource();
-                inputSource.setPublicId( publicId );
-                inputSource.setSystemId( systemId );
+                inputSource.setPublicId( pResolver.filterPossibleURI( publicId ));
+                inputSource.setSystemId( pResolver.filterPossibleURI(systemId ));
             }
             saxSource = new SAXSource( inputSource );
         }
@@ -304,6 +304,7 @@ public class ValidateMojo
         {
             throw new MojoFailureException( "No ValidationSets configured." );
         }
+        checkCatalogHandling();
 
         Object oldProxySettings = activateProxy();
         try

--- a/src/site/apt/transformation.apt
+++ b/src/site/apt/transformation.apt
@@ -70,16 +70,30 @@ Goal properties
 |                    | paths. Defaults to the project directory, in which the POM      |
 |                    | resides.                                                        |
 *--------------------+-----------------------------------------------------------------+
+| catalogHandling    | How to handle entities which cannot be resolved from the        |
+|                    | catalogs. There are 3 possible values: \                        |
+|                    |                                                                 |
+|                    | * 'passThrough' indicates that the entity resolver should       |
+|                    |   attempt to resolve system and public IDs through default      |
+|                    |   mechanisms, typically by resolving URI formatted system IDs.\ |
+|                    |                                                                 |
+|                    | * 'local' indicates that the entity resolver should behave as   |
+|                    |   for 'passThrough' but only where URI's are 'file' format      |
+|                    |   URIs.\                                                        |
+|                    |                                                                 |
+|                    | * 'strict' indicates that any entity which cannot be found in   |
+|                    |   a catalog should generate an error.                           |
+*--------------------+-----------------------------------------------------------------+
 | catalogs           | A set of catalog files, which configure the entity resolver.    |
 |                    | For example, it allows to map public ID's or external URL's to  |
 |                    | local files. Multiple catalog files are supported. In other     |
 |                    | words, to configure a single catalog file, you would need a     |
-|                    | section like this:                                              |
-|                    |                                                                 |
-|                    | \<catalogs\>                                                    |
-|                    |   \<catalog\>mycatalog.xml\</catalog\>                          |
-|                    | \</catalogs\>                                                   |
-|                    |                                                                 |
+|                    | section like this:\                                             |
+|                    | \                                                               |
+|                    | \<catalogs\>\                                                   |
+|                    |   \<catalog\>mycatalog.xml\</catalog\>\                         |
+|                    | \</catalogs\>\                                                  |
+|                    | \                                                               |
 |                    | The interpretation of catalog files is done by the Apache XML   |
 |                    | resolver. See                                                   |
 |                    | {{{http://xml.apache.org/commons/components/resolver/resolver-article.html}this}} |

--- a/src/site/apt/validation.apt
+++ b/src/site/apt/validation.apt
@@ -64,35 +64,49 @@ Goal properties
 
   The "xml:validate" goal offers the following configurable properties:
 
-*----------------+-----------------------------------------------------------------+
-| Property Name  | Description                                                     |
-*----------------+-----------------------------------------------------------------+
-| basedir        | The base directory, which is used for interpreting relative     |
-|                | paths. Defaults to the project directory, in which the POM      |
-|                | resides.                                                        |
-*----------------+-----------------------------------------------------------------+
-| catalogs       | A set of catalog files, which configure the entity resolver.    |
-|                | For example, it allows to map public ID's or external URL's to  |
-|                | local files. Multiple catalog files are supported. In other     |
-|                | words, to configure a single catalog file, you would need a     |
-|                | section like this:                                              |
-|                |                                                                 |
-|                | \<catalogs\>                                                    |
-|                |   \<catalog\>mycatalog.xml\</catalog\>                          |
-|                | \</catalogs\>                                                   |
-|                |                                                                 |
-|                | The interpretation of catalog files is done by the Apache XML   |
-|                | resolver. See                                                   |
-|                | {{{http://xml.apache.org/commons/components/resolver/resolver-article.html}this}} |
-|                | article for details on catalog files and their formats.         |
-*----------------+-----------------------------------------------------------------+
-| validationSets | A validation set configures a set of XML files, which are       |
-|                | validated against a common XML schema. If you want to validate  |
-|                | against multiple schemata, use one validation set per schema.   |
-|                | See the above example, which specifies two validation sets.     |
-|                | The various child elements of a \<validationSet\> section are   |
-|                | listed in the following section.                                |
-*----------------+-----------------------------------------------------------------+
+*-----------------+-----------------------------------------------------------------+
+| Property Name   | Description                                                     |
+*-----------------+-----------------------------------------------------------------+
+| basedir         | The base directory, which is used for interpreting relative     |
+|                 | paths. Defaults to the project directory, in which the POM      |
+|                 | resides.                                                        |
+*-----------------+-----------------------------------------------------------------+
+| catalogHandling | How to handle entities which cannot be resolved from the        |
+|                 | catalogs. There are 3 possible values:\                         |
+|                 |                                                                 |
+|                 | * 'passThrough' indicates that the entity resolver should       |
+|                 |   attempt to resolve system and public IDs through default      |
+|                 |   mechanisms, typically by resolving URI formatted system IDs.\ |
+|                 |                                                                 |
+|                 | * 'local' indicates that the entity resolver should behave as   |
+|                 |   for 'passThrough' but only where URI's are 'file' format      |
+|                 |   URIs.\                                                        |
+|                 |                                                                 |
+|                 | * 'strict' indicates that any entity which cannot be found in   |
+|                 |   a catalog should generate an error.                           |
+*-----------------+-----------------------------------------------------------------+
+| catalogs        | A set of catalog files, which configure the entity resolver.    |
+|                 | For example, it allows to map public ID's or external URL's to  |
+|                 | local files. Multiple catalog files are supported. In other     |
+|                 | words, to configure a single catalog file, you would need a     |
+|                 | section like this:\                                             |
+|                 | \                                                               |
+|                 | \<catalogs\>\                                                   |
+|                 |   \<catalog\>mycatalog.xml\</catalog\>\                         |
+|                 | \</catalogs\>\                                                  |
+|                 | \                                                               |
+|                 | The interpretation of catalog files is done by the Apache XML   |
+|                 | resolver. See                                                   |
+|                 | {{{http://xml.apache.org/commons/components/resolver/resolver-article.html}this}} |
+|                 | article for details on catalog files and their formats.         |
+*-----------------+-----------------------------------------------------------------+
+| validationSets  | A validation set configures a set of XML files, which are       |
+|                 | validated against a common XML schema. If you want to validate  |
+|                 | against multiple schemata, use one validation set per schema.   |
+|                 | See the above example, which specifies two validation sets.     |
+|                 | The various child elements of a \<validationSet\> section are   |
+|                 | listed in the following section.                                |
+*-----------------+-----------------------------------------------------------------+
 
 Validation Set Configuration
 

--- a/src/test/it16/catalog.xml
+++ b/src/test/it16/catalog.xml
@@ -1,0 +1,21 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <system systemId="http://mojohaus.org/schema/non-existent/schema.xsd"
+          uri="schema.xsd"/>
+</catalog>

--- a/src/test/it16/pom.xml
+++ b/src/test/it16/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.xml</groupId>
+  <artifactId>it16</artifactId>
+  <version>0.1</version>
+  <name>Maven XML Plugin IT 16</name>
+  <description>Integration Test 16 for the Maven XML Plugin</description>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>xml-maven-plugin</artifactId>
+        <version>0.2</version>
+        <configuration>
+          <catalogHandling>strict</catalogHandling>
+          <validationSets>
+            <validationSet>
+              <dir>xml</dir>
+              <schemaLanguage>http://www.w3.org/2001/XMLSchema</schemaLanguage>
+              <systemId>https://www.w3.org/2001/XMLSchema.xsd</systemId>
+            </validationSet>
+          </validationSets>
+          <catalogs>
+            <catalog>catalog.xml</catalog>
+          </catalogs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/it16/schema.xsd
+++ b/src/test/it16/schema.xsd
@@ -1,0 +1,30 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified" attributeFormDefault="unqualified"
+    targetNamespace="http://mojohaus.org/schema/non-existent/schema.xsd">
+  <xs:element name="counter">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" minOccurs="0" maxOccurs="unbounded">
+          <xs:complexType/>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/test/it16/xml/test-schema.xsd
+++ b/src/test/it16/xml/test-schema.xsd
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+<xs:element name="note">
+  <xs:complexType>
+    <xs:sequence>
+      <xs:element name="to" type="xs:string"/>
+      <xs:element name="from" type="xs:string"/>
+      <xs:element name="heading" type="xs:string"/>
+      <xs:element name="body" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:element>
+
+</xs:schema>

--- a/src/test/it17/catalog.xml
+++ b/src/test/it17/catalog.xml
@@ -1,0 +1,21 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <public publicId="--COUNTER--"
+          uri="schema2.xsd"/>   <!-- not meant to exist -->
+</catalog>

--- a/src/test/it17/pom.xml
+++ b/src/test/it17/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.xml</groupId>
+  <artifactId>it3</artifactId>
+  <version>0.1</version>
+  <name>Maven XML Plugin IT 3</name>
+  <description>Integration Test 3 for the Maven XML Plugin</description>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>xml-maven-plugin</artifactId>
+        <version>0.2</version>
+        <configuration>
+          <catalogHandling>local</catalogHandling>
+          <validationSets>
+            <validationSet>
+              <dir>xml</dir>
+              <systemId>schema.xsd</systemId>
+            </validationSet>
+          </validationSets>
+          <catalogs>
+            <catalog>catalog.xml</catalog>
+          </catalogs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/it17/schema.xsd
+++ b/src/test/it17/schema.xsd
@@ -1,0 +1,30 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified" attributeFormDefault="unqualified"
+    targetNamespace="xyz0">
+  <xs:element name="counter">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="item" minOccurs="0" maxOccurs="unbounded">
+          <xs:complexType/>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/src/test/it17/xml/doc1.xml
+++ b/src/test/it17/xml/doc1.xml
@@ -1,0 +1,19 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<counter xmlns="xyz0"><item/><item/><item/></counter>
+

--- a/src/test/java/org/codehaus/mojo/xml/test/AbstractXmlMojoTestCase.java
+++ b/src/test/java/org/codehaus/mojo/xml/test/AbstractXmlMojoTestCase.java
@@ -23,20 +23,37 @@ import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import org.apache.maven.execution.DefaultMavenExecutionRequest;
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.execution.MavenSession;
 
 import org.apache.maven.model.Build;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.Mojo;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.PluginParameterExpressionEvaluator;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.plugin.testing.SilentLog;
 import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingRequest;
 import org.codehaus.mojo.xml.AbstractXmlMojo;
 import org.codehaus.mojo.xml.TransformMojo;
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.ComponentConfigurator;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
 import org.codehaus.plexus.resource.DefaultResourceManager;
 import org.codehaus.plexus.resource.loader.FileResourceLoader;
 import org.codehaus.plexus.resource.loader.JarResourceLoader;
 import org.codehaus.plexus.resource.loader.ResourceLoader;
 import org.codehaus.plexus.resource.loader.ThreadContextClasspathResourceLoader;
 import org.codehaus.plexus.resource.loader.URLResourceLoader;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -50,7 +67,16 @@ public abstract class AbstractXmlMojoTestCase
         throws Exception
     {
         File testPom = new File( new File( getBasedir(), pDir ), "pom.xml" );
-        AbstractXmlMojo vm = (AbstractXmlMojo) lookupMojo( getGoal(), testPom );
+        
+        MavenExecutionRequest executionRequest = new DefaultMavenExecutionRequest();
+        ProjectBuildingRequest buildingRequest = executionRequest.getProjectBuildingRequest();
+        ProjectBuilder projectBuilder = this.lookup(ProjectBuilder.class);
+        MavenProject project = projectBuilder.build(testPom, buildingRequest).getProject();
+//        final Build build = new Build();
+//        build.setDirectory( "target" );
+//        project.setBuild(build);
+        project.getBuild().setDirectory("target");
+        AbstractXmlMojo vm = (AbstractXmlMojo) lookupConfiguredMojo(project, getGoal());
         setVariableValueToObject( vm, "basedir", new File( getBasedir(), pDir ) );
         final Log log = new SilentLog();
         DefaultResourceManager rm = new DefaultResourceManager();
@@ -65,16 +91,14 @@ public abstract class AbstractXmlMojoTestCase
         resourceLoaders.put( "url", url );
         setVariableValueToObject( rm, "resourceLoaders", resourceLoaders );
 
-        final Build build = new Build();
-        build.setDirectory( "target" );
-        MavenProjectStub project = new MavenProjectStub()
-        {
-            public Build getBuild()
-            {
-                return build;
-            }
-        };
-        setVariableValueToObject( vm, "project", project );
+//        MavenProjectStub project = new MavenProjectStub()
+//        {
+//            public Build getBuild()
+//            {
+//                return build;
+//            }
+//        };
+//        setVariableValueToObject( vm, "project", project );
         return vm;
     }
 
@@ -107,4 +131,42 @@ public abstract class AbstractXmlMojoTestCase
             return false;
         }
     }
+    
+    
+    
+    @Override   //In maven-plugin-testing-harnes 2.1, this method had a simple error in it which resulted in
+                //the configuration being incorrectly generated.  In later versions, the error has been corrected.
+                //The error is annotated in the comments below.  This method should be removed when upgrading to later
+                //versions.
+    protected Mojo lookupConfiguredMojo( MavenSession session, MojoExecution execution )
+        throws Exception, ComponentConfigurationException
+    {
+        MavenProject project = session.getCurrentProject();
+        MojoDescriptor mojoDescriptor = execution.getMojoDescriptor();
+
+        Mojo mojo = (Mojo) lookup( mojoDescriptor.getRole(), mojoDescriptor.getRoleHint() );
+
+        ExpressionEvaluator evaluator = new PluginParameterExpressionEvaluator( session, execution );
+
+        Xpp3Dom configuration = null;
+        Plugin plugin = project.getPlugin( mojoDescriptor.getPluginDescriptor().getPluginLookupKey() );
+        if ( plugin != null )
+        {
+            configuration = (Xpp3Dom) plugin.getConfiguration();
+        }
+        if ( configuration == null )
+        {
+            configuration = new Xpp3Dom( "configuration" );
+        }
+        //FIX: the parameters were in the wrong order on this call - they have been reversed
+        configuration = Xpp3Dom.mergeXpp3Dom(  configuration ,execution.getConfiguration());
+        //END FIX
+        PlexusConfiguration pluginConfiguration = new XmlPlexusConfiguration( configuration );
+
+        getContainer().lookup( ComponentConfigurator.class, "basic" ).configureComponent( mojo, pluginConfiguration, evaluator, getContainer().getContainerRealm() );
+
+        return mojo;
+    }
+
+    
 }

--- a/src/test/java/org/codehaus/mojo/xml/test/ValidateMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/xml/test/ValidateMojoTest.java
@@ -17,10 +17,10 @@ package org.codehaus.mojo.xml.test;
  */
 
 import org.apache.maven.plugin.MojoExecutionException;
-import org.xml.sax.SAXParseException;
+import org.codehaus.mojo.xml.ValidateMojo;
 
 /**
- * Test case for the {@link CheckFormatMojo}.
+ * Test case for the {@link ValidateMojo}.
  */
 public class ValidateMojoTest
     extends AbstractXmlMojoTestCase
@@ -127,6 +127,47 @@ public class ValidateMojoTest
         catch(Exception e){
             e.printStackTrace();
             fail();
+        }
+    }
+
+    
+    /*
+        Notes on how this test works:
+            - we try to validate a document using a public schema for which we have
+            no mapping in our catalog.  Because the catalogHandling is set to "strict",
+            the test should fail.
+    */
+    /**
+     * Builds and runs the it16 test project (Issue #19 - adding a "strict" setting on all mojo)
+     * @throws Exception 
+     */
+    public void testIt16()
+        throws Exception
+    {
+        try{
+            runTest( "src/test/it16" );
+            fail();
+        }
+        catch(MojoExecutionException e){
+           
+        }
+    }
+
+    
+    /**
+     * Builds and runs the it17 test project (Issue #19 - adding a "strict" setting on all mojo).
+     * This test is just a sanity test of the "local" setting for catalogHandling.
+     * @throws Exception 
+     */
+    public void testIt17()
+        throws Exception
+    {
+        try{
+            runTest( "src/test/it17" );
+        }
+        catch(MojoExecutionException e){
+            fail();
+           
         }
     }
 


### PR DESCRIPTION
Justification: Current implementation will resolve entities that are not
in a catalog by resolving system / public id URLs.  This introduces external
build dependencies which are non-deterministic as those resources can change
or be hacked.
Solution: Introduce new 'catalogHandling' setting which allows the developer
to control how a catalog miss is handled.  Options are 'passThrough' (default
, current behaviour), 'local' (resolve local file or relative URLS), 'strict'
(fail any catalog miss).