### PR TITLE
Fixed #34. Handle relative href in xml-model processing instructions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,13 +163,13 @@
     <dependency>
       <groupId>com.componentcorp.xml.validation</groupId>
       <artifactId>jxvc</artifactId>
-      <version>0.9.3</version>
+      <version>0.9.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.componentcorp.xml.validation</groupId>
       <artifactId>relaxng-compact</artifactId>
-      <version>0.9.3</version>
+      <version>0.9.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/it18/pom.xml
+++ b/src/test/it18/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.xml</groupId>
+  <artifactId>it15</artifactId>
+  <version>0.1</version>
+  <name>Maven XML Plugin IT 15</name>
+  <description>Integration Test 15 for the Maven XML Plugin</description>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>xml-maven-plugin</artifactId>
+        <version>0.2</version>
+        <configuration>
+          <validationSets>
+            <validationSet>
+              <dir>xml</dir>
+              <schemaLanguage>http://componentcorp.com/xml/ns/xml-model/1.0</schemaLanguage>
+            </validationSet>
+          </validationSets>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/it18/schema.rnc
+++ b/src/test/it18/schema.rnc
@@ -1,0 +1,5 @@
+
+element counter { 
+    
+    element item { empty }*
+}

--- a/src/test/it18/xml/doc1.xml
+++ b/src/test/it18/xml/doc1.xml
@@ -1,0 +1,21 @@
+<!--
+
+   Copyright 2006 The Apache Software Foundation.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+-->
+
+<?xml-model href="../schema.rnc" schematypens="http://www.iana.org/assignments/media-types/application/relax-ng-compact-syntax" ?>
+<counter ><item/><item/><item/></counter>
+

--- a/src/test/java/org/codehaus/mojo/xml/test/ValidateMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/xml/test/ValidateMojoTest.java
@@ -143,6 +143,23 @@ public class ValidateMojoTest
 
     
     /**
+     * Builds, and runs the it18 project.
+     * @throws Exception The test failed.
+     */
+    public void testIt18()
+        throws Exception
+    {
+        try{
+            runTest( "src/test/it18" );
+        }
+        catch(Exception e){
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    
+    /**
      * Builds and runs the xinclude test project
      * @throws Exception The test failed.
      */


### PR DESCRIPTION
Motivation: When resolving xml-model style validations, relative href 
do not work.  As this is relying on the EntityResolver, there are possibly
other relative entity resolutions which do not work either.

Solution: Added relative URI handling to the resolveURL method of Resolver
class.  Code attempts the original code path before attempting to resolve
relative URI's to preserver legacy behavior as much as possible.
 - also updated latest jxvc version.

Fixed #34 