### PR TITLE
Fixed #41. "addedToClassPath" setting not using proper outputDir default

### DIFF
--- a/src/main/java/org/codehaus/mojo/xml/TransformMojo.java
+++ b/src/main/java/org/codehaus/mojo/xml/TransformMojo.java
@@ -566,7 +566,7 @@ public class TransformMojo
 
         if ( pTransformationSet.isAddedToClasspath() )
         {
-            addToClasspath( pTransformationSet.getOutputDir() );
+            addToClasspath( getOutputDir( pTransformationSet.getOutputDir() ));
         }
     }
 

--- a/src/test/xinclude-xsl/pom.xml
+++ b/src/test/xinclude-xsl/pom.xml
@@ -32,6 +32,7 @@
 			<configuration>
 				<transformationSets>
 					<transformationSet>
+                                                <addedToClasspath>true</addedToClasspath>
 						<xincludeAware>true</xincludeAware>
 						<dir>xml</dir>
 						<stylesheet>xsl/copy.xsl</stylesheet>
@@ -41,6 +42,7 @@
 					</transformationSet>
 
 					<transformationSet>
+                                                <addedToClasspath>true</addedToClasspath>
 						<xincludeAware>false</xincludeAware>
 						<dir>xml</dir>
 						<stylesheet>xsl/copy.xsl</stylesheet>


### PR DESCRIPTION
- Default handling was not correctly called when setting "addedToClasspath"
=true.
- Also modified one existing test case so that it would stumble over this
problem should it arise again.