### PR TITLE
[site/examples] Typos in XSD schema validation

### DIFF
--- a/src/site/apt/examples/validate-schema.apt
+++ b/src/site/apt/examples/validate-schema.apt
@@ -23,7 +23,7 @@
 Checking whether XML files are matching an XML Schema
 
   The following configuration snippet would check, whether all files
-  in the directory <<<src/main/xsd>>> are matching the schema
+  in the directory <<<src/main/xml>>> are matching the schema
   <<<src/main/xmlschema.xsd>>>.
 
 +----------------------------------------------------------------------------------

--- a/src/site/apt/examples/validate-schema.apt
+++ b/src/site/apt/examples/validate-schema.apt
@@ -43,8 +43,8 @@ Checking whether XML files are matching an XML Schema
         <configuration>
           <validationSets>
             <validationSet>
-              <dir>src/main/xsd</dir>
-              <systemId>src/main/xmlschema.xml</systemId>
+              <dir>src/main/xml</dir>
+              <systemId>src/main/xmlschema.xsd</systemId>
             </validationSet>
           </validationSets>
         </configuration>


### PR DESCRIPTION
feels less confusing to have the `<dir>` being `/xml`, and the `xmlschema` file with a `xsd` extension